### PR TITLE
Remove references to Regions in our app

### DIFF
--- a/loan-calculator-client/src/components/AdminSignup.js
+++ b/loan-calculator-client/src/components/AdminSignup.js
@@ -23,7 +23,7 @@ class AdminSignup extends React.Component {
 						Name: <Input placeholder="John Doe" name='name' value={this.state.name} onChange={this.handleChange}/>
 						<br />
 						<br />
-						Email: <Input placeholder="john@regions.com" name='email' value={this.state.email} onChange={this.handleChange}/>
+						Email: <Input placeholder="john@bank.com" name='email' value={this.state.email} onChange={this.handleChange}/>
 						<br />
 						<br />
 						Password: <Input.Password placeholder="p@$$w0r6" name='password' value={this.state.password} onChange={this.handleChange}/>

--- a/loan-calculator-client/src/scripts/chatbot.js
+++ b/loan-calculator-client/src/scripts/chatbot.js
@@ -2,7 +2,7 @@ const whatIsQuestion = "What is...";
 const loanQuestion = "Loan-based questions";
 const interestQuestion = "What is an interest payment?";
 const loanTermQuestion = "What is a loan term?";
-const redirectQuestion = "Chat with a Regions representative";
+const redirectQuestion = "Chat with an advisor";
 const principalBalanceQuestion = "Why are the Principal Balance and the Payoff Amount Different?";
 const autoLoanQuestion = "How does this auto loan work?";
 const latePaymentQuestion = "How is this loan affected by late payments?";
@@ -12,7 +12,7 @@ const loanTermResponse = "The loan term is the length of time that you have to r
 const principalBalanceResponse = "The Payoff Amount represents the principal balance, plus accrued interest and any applicable fees. This is the amount you would have to pay to fully pay off your car."
 const autoLoanResponse = "This is a simple interest loan. Interest is accrued against the remaining principle daily over the life of the loan. As the principal is paid off, the monthly interest decreases, meaning more of our payment goes towards principal each month."
 const latePaymentResponse = "Late payments can result in late fees. It will also cause more interest to accrue between payments. This means you would pay more interest over the life of the loan."
-const redirectResponse = "Please wait while I connect you with a Regions representative...";
+const redirectResponse = "Please wait while I connect you with a loan advisor...";
 
 function getChatbotResponse(context) {
     let response;


### PR DESCRIPTION
All mentions of Regions have been replaced with generic phrases like "bank" or "advisor." Closes #60 