### PR TITLE
54 tooltips

### DIFF
--- a/loan-calculator-client/package-lock.json
+++ b/loan-calculator-client/package-lock.json
@@ -18,24 +18,24 @@
       "integrity": "sha512-LrX0OGZtW+W6iLnTAqnTaoIsRelYeuLZWsrmBJFUXDALQphPsN8cE5DCsmoSlL0QYb94BQxINiuS70Ar/8BNgA=="
     },
     "@ant-design/icons": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.2.2.tgz",
-      "integrity": "sha512-DrVV+wcupnHS7PehJ6KiTcJtAR5c25UMgjGECCc6pUT9rsvw0AuYG+a4HDjfxEQuDqKTHwW+oX/nIvCymyLE8Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.3.0.tgz",
+      "integrity": "sha512-UoIbw4oz/L/msbkgqs2nls2KP7XNKScOxVR54wRrWwnXOzJaGNwwSdYjHQz+5ETf8C53YPpzMOnRX99LFCdeIQ==",
       "requires": {
-        "@ant-design/colors": "^3.1.0",
+        "@ant-design/colors": "^5.0.0",
         "@ant-design/icons-svg": "^4.0.0",
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
         "insert-css": "^2.0.0",
         "rc-util": "^5.0.1"
       },
       "dependencies": {
         "@ant-design/colors": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",
-          "integrity": "sha512-YKgNbG2dlzqMhA9NtI3/pbY16m3Yl/EeWBRa+lB1X1YaYxHrxNexiQYCLTWO/uDvAjLFMEDU+zR901waBtMtjQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-5.0.0.tgz",
+          "integrity": "sha512-Pe1rYorgVC1v4f+InDXvIlQH715pO1g7BsOhy/ehX/U6ebPKqojmkYJKU3lF+84Zmvyar7ngZ28hesAa1nWjLg==",
           "requires": {
-            "tinycolor2": "^1.4.1"
+            "@ctrl/tinycolor": "^3.1.6"
           }
         }
       }
@@ -1213,6 +1213,11 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
+    },
+    "@ctrl/tinycolor": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.1.7.tgz",
+      "integrity": "sha512-/0C6fjXbCwu22k8mMsKRSAo9zgu61d2p75Or9IuIC0Vu5CWN88t2QHK93LhNnxnqHWf5SFwFU28w9cKfTmnfvg=="
     },
     "@emotion/babel-utils": {
       "version": "0.6.10",

--- a/loan-calculator-client/package.json
+++ b/loan-calculator-client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@ant-design/icons": "^4.3.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/loan-calculator-client/src/components/AffordabilityCalculator.js
+++ b/loan-calculator-client/src/components/AffordabilityCalculator.js
@@ -8,6 +8,8 @@ import {
 import { calculateAffordability } from '../scripts/calculators';
 import '../css/AffordabilityCalculator.css';
 import BarChart from './BarChart';
+import ReactTooltip from 'react-tooltip';
+import { InfoCircleTwoTone } from '@ant-design/icons';
 
 function AffordabilityCalculator() {
   // create the inputs for our calculator
@@ -105,6 +107,17 @@ function AffordabilityCalculator() {
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                     parser={value => value.replace(/\$\s?|(,*)/g, '')}
                   />
+                  <InfoCircleTwoTone 
+                    data-tip='The vehicle loan payment you can afford to make each month' 
+                    style={{ margin: 2 }}
+                  />
+                  <ReactTooltip 
+                    place="bottom" 
+                    class='tooltip-style' 
+                    effect='solid'
+                    type='info'
+                    offset="{'top': -5}"
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Interest Rate">
@@ -112,7 +125,12 @@ function AffordabilityCalculator() {
                   <InputNumber 
                     min={0} 
                     formatter={value => `${value}%`}
-                    parser={value => value.replace('%', '')}/>
+                    parser={value => value.replace('%', '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The rate at which interest will be charged on your outstanding vehicle loan balance' 
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
             </Form>
@@ -136,7 +154,12 @@ function AffordabilityCalculator() {
                   <InputNumber 
                     min={0} 
                     formatter={value => `${value}%`}
-                    parser={value => value.replace('%', '')}/>
+                    parser={value => value.replace('%', '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The sales tax rate that you will pay when you purchase your vehicle' 
+                    style={{ margin: 1 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Cash rebate/back">
@@ -144,7 +167,12 @@ function AffordabilityCalculator() {
                   <InputNumber 
                     min={0}
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                    parser={value => value.replace(/\$\s?|(,*)/g, '')} />
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The amount of the dealer or manufacturer incentive to purchase a specific vehicle' 
+                    style={{ margin: 1 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Value of your trade-in">
@@ -152,7 +180,12 @@ function AffordabilityCalculator() {
                   <InputNumber 
                     min={0} 
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                    parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='What the dealer will give you for a used vehicle at trade-in' 
+                    style={{ margin: 1 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Amount owed on trade-in">
@@ -160,7 +193,12 @@ function AffordabilityCalculator() {
                   <InputNumber 
                     min={0} 
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                    parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The balance on any outstanding loan that may exist for your trade-in' 
+                    style={{ margin: 1 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Down payment amount">
@@ -168,7 +206,12 @@ function AffordabilityCalculator() {
                   <InputNumber
                     min={0} 
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                    parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The amount of money you will pay up front for your vehicle' 
+                    style={{ margin: 1 }}
+                  />
                 </Form.Item>
               </Form.Item>
             </Form>

--- a/loan-calculator-client/src/components/CashBackCalculator.js
+++ b/loan-calculator-client/src/components/CashBackCalculator.js
@@ -8,6 +8,9 @@ import {
 import { calculateCashBack } from '../scripts/calculators';
 import '../css/CashBackCalculator.css';
 import BarChart from './BarChart';
+import ReactTooltip from 'react-tooltip';
+import { InfoCircleTwoTone } from '@ant-design/icons';
+
 
 function CashBackCalculator() {
   // create the inputs for our calculator
@@ -111,29 +114,64 @@ function CashBackCalculator() {
               <Form.Item label="Vehicle Purchase Price">
                 <Form.Item name="purchasePrice" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                  parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The price you pay for your vehicle including extras and upgrades' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
+                  <ReactTooltip 
+                    place="bottom" 
+                    class='tooltip-style' 
+                    effect='solid'
+                    type='info'
+                    offset="{'top': -5}"
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Cash Back">
                 <Form.Item name="cashBack" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                  parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The amount of the dealer or manufacturer incentive to purchase a specific vehicle' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Low Interest Rate">
                 <Form.Item name="lowInterestRate" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `${value}%`}
-                  parser={value => value.replace('%', '')}/>
+                    formatter={value => `${value}%`}
+                    parser={value => value.replace('%', '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The special incentive low interest rate offered on this vehicle loan' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Sales Tax Rate">
                 <Form.Item name="taxRate" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `${value}%`}
-                  parser={value => value.replace('%', '')}/>
+                    formatter={value => `${value}%`}
+                    parser={value => value.replace('%', '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The sales tax rate that you will pay when you purchase your vehicle' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
             </Form>
@@ -152,15 +190,29 @@ function CashBackCalculator() {
               <Form.Item label="Value of Trade-in">
                 <Form.Item name="tradeInValue" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                  parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='What the dealer will give you for a used vehicle at trade-in' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Amount Owed on Trade-in">
                 <Form.Item name="tradeInOwed" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                  parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The balance on any outstanding loan that may exist for your trade-in' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
             </Form>
@@ -180,20 +232,40 @@ function CashBackCalculator() {
               <Form.Item label="Loan Term (months)">
                 <Form.Item name="loanTerm" noStyle>
                   <InputNumber min={0} />
+                  <InfoCircleTwoTone 
+                    data-tip='The lenth of time you have to repay your loan in months' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Interest Rate">
                 <Form.Item name="interestRate" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `${value}%`}
-                  parser={value => value.replace('%', '')}/>
+                    formatter={value => `${value}%`}
+                    parser={value => value.replace('%', '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The rate at which interest will be charged on your outstanding vehicle loan balance' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Down Payment">
                 <Form.Item name="downPayment" noStyle>
                   <InputNumber min={0} 
-                  formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
-                  parser={value => value.replace(/\$\s?|(,*)/g, '')}/>
+                    formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
+                    parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The amount of money you will pay up front for your vehicle' 
+                    data-effect='solid'
+                    data-type='info'
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
             </Form>

--- a/loan-calculator-client/src/components/MonthlyPaymentCalculator.js
+++ b/loan-calculator-client/src/components/MonthlyPaymentCalculator.js
@@ -12,6 +12,7 @@ import { calculateLoanData, calculateAmortizedLoanData } from '../scripts/calcul
 import '../css/MonthlyPaymentCalculator.css';
 import BarChart from './BarChart'
 import ReactTooltip from 'react-tooltip';
+import { InfoCircleTwoTone } from '@ant-design/icons';
 
 
 function MonthlyPaymentCalculator() {
@@ -192,6 +193,17 @@ function MonthlyPaymentCalculator() {
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                     parser={value => value.replace(/\$\s?|(,*)/g, '')}
                   />
+                  <InfoCircleTwoTone 
+                    data-tip='The price you pay for your vehicle including extras and upgrades' 
+                    style={{ margin: 2 }}
+                  />
+                  <ReactTooltip 
+                    place="bottom" 
+                    class='tooltip-style' 
+                    effect='solid'
+                    type='info'
+                    offset="{'top': -5}"
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Cash Back">
@@ -201,6 +213,10 @@ function MonthlyPaymentCalculator() {
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                     parser={value => value.replace(/\$\s?|(,*)/g, '')}
                   />
+                  <InfoCircleTwoTone 
+                    data-tip='The amount of the dealer or manufacturer incentive to purchase a specific vehicle' 
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Sales Tax Rate">
@@ -209,6 +225,10 @@ function MonthlyPaymentCalculator() {
                     min={0}
                     formatter={value => `${value}%`}
                     parser={value => value.replace('%', '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The sales tax rate that you will pay when you purchase your vehicle' 
+                    style={{ margin: 2 }}
                   />
                 </Form.Item>
               </Form.Item>
@@ -233,6 +253,10 @@ function MonthlyPaymentCalculator() {
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                     parser={value => value.replace(/\$\s?|(,*)/g, '')}
                   />
+                  <InfoCircleTwoTone 
+                    data-tip='What the dealer will give you for a used vehicle at trade-in' 
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Amount Owed on Trade-in">
@@ -241,6 +265,10 @@ function MonthlyPaymentCalculator() {
                     min={0}
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                     parser={value => value.replace(/\$\s?|(,*)/g, '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The balance on any outstanding loan that may exist for your trade-in' 
+                    style={{ margin: 2 }}
                   />
                 </Form.Item>
               </Form.Item>
@@ -262,6 +290,10 @@ function MonthlyPaymentCalculator() {
               <Form.Item label="Loan Term (months)">
                 <Form.Item name="loanTerm" noStyle>
                   <InputNumber min={0} />
+                  <InfoCircleTwoTone 
+                    data-tip='The length of time you have to repay your loan in months' 
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
               <Form.Item label="Interest Rate">
@@ -270,6 +302,10 @@ function MonthlyPaymentCalculator() {
                     min={0}
                     formatter={value => `${value}%`}
                     parser={value => value.replace('%', '')}
+                  />
+                  <InfoCircleTwoTone 
+                    data-tip='The rate at which interest will be charged on you routstanding vehicle loan balance' 
+                    style={{ margin: 2 }}
                   />
                 </Form.Item>
               </Form.Item>
@@ -280,6 +316,10 @@ function MonthlyPaymentCalculator() {
                     formatter={value => `$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, ',')}
                     parser={value => value.replace(/\$\s?|(,*)/g, '')}
                   />
+                  <InfoCircleTwoTone 
+                    data-tip='The amount of money you will pay up front for your vehicle' 
+                    style={{ margin: 2 }}
+                  />
                 </Form.Item>
               </Form.Item>
             </Form>
@@ -287,13 +327,21 @@ function MonthlyPaymentCalculator() {
         </Collapse>
       </div>
       <div className='multiple-inputs' style={multipleDataStyle}>
-        <Input placeholder="Loan name" style={{ width: 200, margin: 10 }} onChange={onNameChange} data-tip='Save multiple loan alternatives'></Input>
-        <ReactTooltip place="bottom"/>
+        <Input 
+          placeholder="Loan name" 
+          style={{ width: 200, margin: 10 }} 
+          onChange={onNameChange} 
+          data-tip='Save multiple loan alternatives'
+        ></Input>
         <Button type="primary" style={{ margin: 10 }} onClick={handleSaveClick}>Save</Button>
-        <Select defaultValue="None" style={{ width: 120, margin:10 }} onChange={handleSelectChange} data-tip='Choose loans to compare'>
+        <Select 
+          defaultValue="None" 
+          style={{ width: 120, margin:10 }} 
+          onChange={handleSelectChange} 
+          data-tip='Choose loans to compare'
+        >
           {Object.keys(dropdownData.inputValues).map((elem) =><Option value={elem}>{elem}</Option>)}
         </Select>
-        <ReactTooltip place="bottom"/>
         <Button type="primary" style={{ margin: 10 }} onClick={handleLoadClick}>Load</Button>
       </div>
       <div className='calc-outputs'>

--- a/loan-calculator-client/src/css/AffordabilityCalculator.css
+++ b/loan-calculator-client/src/css/AffordabilityCalculator.css
@@ -26,3 +26,7 @@ table {
 td {
     padding: 8px;
 }
+
+.tooltip-style {
+    padding: 2px;
+}

--- a/loan-calculator-client/src/css/CashBackCalculator.css
+++ b/loan-calculator-client/src/css/CashBackCalculator.css
@@ -10,3 +10,7 @@
 .ant-form-item-control-input-content {
     padding-right: 20px;
 }
+
+.tooltip-style {
+    padding: 2px;
+}

--- a/loan-calculator-client/src/css/MonthlyPaymentCalculator.css
+++ b/loan-calculator-client/src/css/MonthlyPaymentCalculator.css
@@ -44,3 +44,7 @@
 .ant-collapse-content > .ant-collapse-content-box {
     padding-bottom: 0 !important;
 }
+
+.tooltip-style {
+    padding: 2px;
+}

--- a/loan-calculator-client/src/css/MonthlyPaymentCalculator.css
+++ b/loan-calculator-client/src/css/MonthlyPaymentCalculator.css
@@ -39,6 +39,7 @@
 .ant-collapse > .ant-collapse-item > .ant-collapse-header {
     padding: 0 !important;
     padding-left: 40px !important;
+    color: #528400 !important;
 }
 
 .ant-collapse-content > .ant-collapse-content-box {


### PR DESCRIPTION
This pull request is to code review before merging 54-Toolips branch to development. I worked on adding tooltips to every input for all 3 calculators. One has to hover over the info icon in order to display the tooltip describing the input. I changed the design of the default react tooltip to match our branding. The following is a picture from the monthly payment calculator showing the info icons and a tooltip.
![Screenshot (282)](https://user-images.githubusercontent.com/46834143/99152602-c3512600-2670-11eb-8122-88387d8adebf.png)
